### PR TITLE
Copying should copy empty directories

### DIFF
--- a/tasks/task-helpers.coffee
+++ b/tasks/task-helpers.coffee
@@ -28,11 +28,12 @@ module.exports = (grunt) ->
           destinationPath = path.join(destination, path.relative(source, sourcePath))
           copyFile(sourcePath, destinationPath)
         onDirectory = (sourcePath) ->
+          destinationPath = path.join(destination, path.relative(source, sourcePath))
           if fs.isSymbolicLinkSync(sourcePath)
-            destinationPath = path.join(destination, path.relative(source, sourcePath))
             copyFile(sourcePath, destinationPath)
             false
           else
+            grunt.file.mkdir(destinationPath, fs.statSync(sourcePath).mode) unless grunt.file.exists(destinationPath)
             true
         fs.traverseTreeSync source, onFile, onDirectory
       catch error


### PR DESCRIPTION
grunt.file.copy creates intermediate directories if necessary, but if there are no files inside a directory, this ensures that we still create the directory.

One case where this comes up is that atom-shell creates a bunch of empty directories to make navigator.language work (https://github.com/atom/atom-shell/pull/363/files), so this grunt task should copy those over as well.
