### PR TITLE
Remove unavailable parameter from bootstrap command

### DIFF
--- a/tasks/build-atom-shell-task.coffee
+++ b/tasks/build-atom-shell-task.coffee
@@ -114,7 +114,7 @@ module.exports = (grunt) ->
 
     bootstrapCmd =
       cmd: 'python'
-      args: ['script/bootstrap.py', '-v', '-y']
+      args: ['script/bootstrap.py', '-v']
       opts: cmdOptions
       stdout: stdout
       stderr: stderr


### PR DESCRIPTION
I was receiving the following warning before this change:

```bash
Running "build-atom-shell" task
>> usage: bootstrap.py [-h] [-u URL] [-v]
>> bootstrap.py: error: unrecognized arguments: -y
>> usage: bootstrap.py [-h] [-u URL] [-v]
>> bootstrap.py: error: unrecognized arguments: -y
Warning: null Use --force to continue.

Aborted due to warnings.
```

This change seems to fix that.

Thanks!